### PR TITLE
[#1] Goのコードの変数名やメソッド名をGoの命名規則に準拠させる

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -15,12 +15,12 @@ type datasourceName struct {
 	port     int
 	user     string
 	password string
-	dbName   string
+	dbname   string
 	sslMode  string
 }
 
 func getDataSourceNameString(dsn datasourceName) string {
-	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dsn.host, dsn.port, dsn.user, dsn.password, dsn.dbName, dsn.sslMode)
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dsn.host, dsn.port, dsn.user, dsn.password, dsn.dbname, dsn.sslMode)
 }
 
 type Idol struct {
@@ -81,7 +81,7 @@ func main() {
 		port:     5423,
 		user:     "postgres",
 		password: "postgres",
-		dbName:   "postgres",
+		dbname:   "postgres",
 		sslMode:  "disable",
 	}
 	dsnString := getDataSourceNameString(dsn)

--- a/server/main.go
+++ b/server/main.go
@@ -24,14 +24,14 @@ func getDataSourceNameString(dsn datasourceName) string {
 }
 
 type Idol struct {
-	Id          string
-	Name        string
-	Age         int
-	Height      int
-	Birth_place string
-	Birth_day   string
-	Blood_type  string
-	Unit        string
+	Id         string
+	Name       string
+	Age        int
+	Height     int
+	Birthplace string
+	Birthday   string
+	Bloodtype  string
+	Unit       string
 }
 
 var IdolType = graphql.NewObject(graphql.ObjectConfig{
@@ -64,7 +64,7 @@ func getSameAgeIdols(db *sql.DB, age int) []Idol {
 	var result []Idol
 	for rows.Next() {
 		var i Idol
-		rows.Scan(&i.Id, &i.Name, &i.Age, &i.Height, &i.Birth_place, &i.Birth_day, &i.Blood_type, &i.Unit)
+		rows.Scan(&i.Id, &i.Name, &i.Age, &i.Height, &i.Birthplace, &i.Birthday, &i.Bloodtype, &i.Unit)
 
 		if i.Age == age {
 			result = append(result, i)

--- a/server/main.go
+++ b/server/main.go
@@ -16,11 +16,11 @@ type datasourceName struct {
 	user     string
 	password string
 	dbname   string
-	sslMode  string
+	sslmode  string
 }
 
 func getDataSourceNameString(dsn datasourceName) string {
-	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dsn.host, dsn.port, dsn.user, dsn.password, dsn.dbname, dsn.sslMode)
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dsn.host, dsn.port, dsn.user, dsn.password, dsn.dbname, dsn.sslmode)
 }
 
 type Idol struct {
@@ -82,7 +82,7 @@ func main() {
 		user:     "postgres",
 		password: "postgres",
 		dbname:   "postgres",
-		sslMode:  "disable",
+		sslmode:  "disable",
 	}
 	dsnString := getDataSourceNameString(dsn)
 	db, err := sql.Open("postgres", dsnString)


### PR DESCRIPTION
#1 