### PR TITLE
[#12] age引数無しのクエリに対応する

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -103,8 +103,10 @@ func main() {
 						if ok {
 							result := getSameAgeIdols(db, ageQuery)
 							return result, nil
+						} else {
+							// TODO: [#12] 全件返す処理を追加
+							return nil, nil
 						}
-						return nil, nil
 					},
 					Args: graphql.FieldConfigArgument{
 						"age": &graphql.ArgumentConfig{

--- a/server/main.go
+++ b/server/main.go
@@ -133,7 +133,7 @@ func main() {
 		RequestString: query,
 	}
 	r := graphql.Do(params)
-	if len(r.Errors) > 0 {
+	if r.HasErrors() {
 		log.Fatal(r.Errors)
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -148,6 +148,6 @@ func main() {
 		log.Fatal(r.Errors)
 	}
 
-	rJSON, _ := json.Marshal(r)
-	log.Printf("%s \n", rJSON) // {"data":{"idols":[{"id":16,"name":"有栖川 夏葉"},{"id":26,"name":"斑鳩 ルカ"}]}}
+	output, err := json.MarshalIndent(r, "", "\t")
+	log.Printf("%s \n", output)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -34,6 +34,10 @@ type Idol struct {
 	Unit       string
 }
 
+type Option struct {
+	age int
+}
+
 var IdolType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Idol",
 	Fields: graphql.Fields{
@@ -54,9 +58,14 @@ var IdolType = graphql.NewObject(graphql.ObjectConfig{
 	},
 })
 
-func getSameAgeIdols(db *sql.DB, age int) []Idol {
-	st := fmt.Sprintf("select * from idol where age=%d", age)
-	rows, err := db.Query(st)
+func getSameAgeIdols(db *sql.DB, o Option) []Idol {
+	var stx string
+	if o.age == 0 {
+		stx = "select * from idol order by id"
+	} else {
+		stx = fmt.Sprintf("select * from idol where age=%d order by id", o.age)
+	}
+	rows, err := db.Query(stx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,7 +75,7 @@ func getSameAgeIdols(db *sql.DB, age int) []Idol {
 		var i Idol
 		rows.Scan(&i.Id, &i.Name, &i.Age, &i.Height, &i.Birthplace, &i.Birthday, &i.Bloodtype, &i.Unit)
 
-		if i.Age == age {
+		if o.age == 0 || i.Age == o.age {
 			result = append(result, i)
 		}
 
@@ -101,11 +110,11 @@ func main() {
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						ageQuery, ok := p.Args["age"].(int)
 						if ok {
-							result := getSameAgeIdols(db, ageQuery)
+							result := getSameAgeIdols(db, Option{age: ageQuery})
 							return result, nil
 						} else {
-							// TODO: [#12] 全件返す処理を追加
-							return nil, nil
+							result := getSameAgeIdols(db, Option{})
+							return result, nil
 						}
 					},
 					Args: graphql.FieldConfigArgument{


### PR DESCRIPTION
#12 

## やったこと
クエリの `idols` に `age` の指定が無い時はアイドル全件を返す処理を追加した

```
        query := `
		{
			idols {
				id
				name
			}
		}
	`
```

↓

```
docker-compose exec server go mod download
docker-compose exec server go run main.go
2022/01/23 05:23:22 {
        "data": {
                "idols": [
                        {
                                "id": 1,
                                "name": "櫻木 真乃"
                        },
                        {
                                "id": 2,
                                "name": "八宮 めぐる"
                        },
                        {
                                "id": 3,
                                "name": "風野 灯織"
                        },
                        {
                                "id": 4,
                                "name": "月岡 恋鐘"
                        },
                        ...
                        {
                                "id": 26,
                                "name": "斑鳩 ルカ"
                        }
                ]
        }
} 
```